### PR TITLE
Also trigger ducklake distribution on a nightly base

### DIFF
--- a/.github/workflows/Workflow-Trigger.yml
+++ b/.github/workflows/Workflow-Trigger.yml
@@ -35,6 +35,7 @@ jobs:
         ./trigger.sh duckdb '{"ref": "refs/heads/v1.4-andium"}' Main.yml
         ./trigger.sh duckdb '{"ref": "refs/heads/v1.4-andium", "inputs": {"skip_tests": "false", "git_ref": "v1.4-andium", "run_all": "true", "twine_upload": "true"}}' InvokeCI.yml
         ./trigger.sh duckdb '{"ref": "refs/heads/main", "inputs": {"skip_tests": "false", "git_ref": "main", "run_all": "true", "twine_upload": "true"}}' InvokeCI.yml
+        ./trigger.sh ducklake '{"ref": "refs/heads/v1.4-andium"}' MainDistributionPipeline.yml
         #./trigger.sh duckdb '{"event_type": "nightly-build"}'
 
     - name: Trigger DuckDB-Wasm workflow (in duckdb)


### PR DESCRIPTION
This is still very hacky, given it relies on chaning this repo explicitly, but I think this + https://github.com/duckdb/ducklake/pull/480 should have (on a nightly basis) both duckdb nightlies builds for `v1.4-andium` AND ducklake nightlies builds for `v1.4-andium`.

FYI: @pdet

If this works out tonight / over the weekend, I'd say this has to be documented and more clearly exposed, so that then also `httpfs` or other relevant extensions can be added>