### PR TITLE
Use boolean skip_tests/run_all for main InvokeCI dispatch

### DIFF
--- a/.github/workflows/Workflow-Trigger.yml
+++ b/.github/workflows/Workflow-Trigger.yml
@@ -136,7 +136,11 @@ jobs:
           echo "Dispatching branch-scoped workflows for $branch"
           ./trigger.sh duckdb "$(printf '{"ref":"refs/heads/%s"}' "$branch")" NightlyTests.yml
           ./trigger.sh duckdb "$(printf '{"ref":"refs/heads/%s"}' "$branch")" Main.yml
-          ./trigger.sh duckdb "$(printf '{"ref":"refs/heads/%s","inputs":{"skip_tests":"false","git_ref":"%s","run_all":"true","twine_upload":"true"}}' "$branch" "$branch")" InvokeCI.yml
+          if [[ "$branch" == "main" ]]; then
+            ./trigger.sh duckdb "$(printf '{"ref":"refs/heads/%s","inputs":{"skip_tests":false,"git_ref":"%s","run_all":true,"twine_upload":"true"}}' "$branch" "$branch")" InvokeCI.yml
+          else
+            ./trigger.sh duckdb "$(printf '{"ref":"refs/heads/%s","inputs":{"skip_tests":"false","git_ref":"%s","run_all":"true","twine_upload":"true"}}' "$branch" "$branch")" InvokeCI.yml
+          fi
         done <<< "$changed_branches"
 
     - name: Trigger non-gated workflows


### PR DESCRIPTION
## Summary
- send `skip_tests` and `run_all` as JSON booleans when dispatching `InvokeCI.yml` for `main`
- keep existing string-typed payload unchanged for non-main branches (including v1.5 branches)

Related duckdb [PR](https://github.com/duckdb/duckdb/pull/22131).

## Testing
- verified workflow file diff and dispatch payload branch split